### PR TITLE
Migrate plugin to VCV rack V2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "Qwelk",
   "name": "Qwelk",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "brand": "Qwelk",
   "author": "raincheque",

--- a/src/NEWS.cpp
+++ b/src/NEWS.cpp
@@ -104,7 +104,8 @@ void ModuleNews::process(const ProcessArgs& args)
         news = ceil(news);
 
     // wrap the bits around, e.g. wrap = 2, 1001 ->  0110 / wrap = -3,  1001 -> 0011
-    uint32_t bits = *(reinterpret_cast<uint32_t *>(&news));
+    uint32_t bits;
+    memcpy(&bits, &news, sizeof news);
     if (wrap > 0)
         bits = (bits << wrap) | (bits >> (32 - wrap));
     else if (wrap < 0) {
@@ -112,10 +113,11 @@ void ModuleNews::process(const ProcessArgs& args)
         bits = (bits >> wrap) | (bits << (32 - wrap));
     }
 
-    news = *((float *)&bits);
+    memcpy(&news, &bits, sizeof bits);
 
     // extract the key out the bits which represent the input signal
-    uint32_t key = *(reinterpret_cast<uint32_t *>(&news));
+    uint32_t key;
+    memcpy(&key, &news, sizeof news);
 
     // reset grid
     for (int i = 0; i < GSIZE; ++i)


### PR DESCRIPTION
Converted the plugin to VCV Rack V2. It's less painful than the V1 migration, but there are a few things you need to verify to be compliant. I'll have packages for Linux, Mac and Windows posted under the Issues [post for migration](https://github.com/raincheque/qwelk/issues/13) for users to test the re-built plugin.